### PR TITLE
Complain if either the text or data segments are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ Command line syntax for these Options:
 
    positional arguments:
      o65file     Input o65 code file to be converted
-     sosfile     SOS.DRIVER file to list the contained drivers
+     sosfile     SOS.DRIVER file to add driver to (driver must not already exist)
      
    usage: A3Driverutil.py update [-h] o65file sosfile
 
    positional arguments:
      o65file     Input o65 code file to be converted
-     sosfile     SOS.DRIVER file to be updated
+     sosfile     SOS.DRIVER file to be updated (an existing driver will be updated)
 ```
 
 ## Convert o65 binary and output as driver binary file

--- a/a3driverutil.py
+++ b/a3driverutil.py
@@ -174,7 +174,14 @@ def convert_o65(file):
         #print ("tlen: ",tlen)
         #print ("dbase: ",dbase)
         #print ("dlen: ",dlen)
-        
+
+        if tlen == 0:
+            print("No text segment found; ensure your driver defines .segment \"TEXT\"")
+            exit(1)
+        if dlen == 0:
+            print("No data segment found; ensure your driver defines .segment \"DATA\"")
+            exit(1)
+
         #skip over header options
         olen = readUnpack(o65file,1,type = '1') 
         while olen != 0 :  #0 marks end of options header


### PR DESCRIPTION
Don't ask me how I came across this... but suffices to say I wasted a bunch of time debugging the python until I realized it was because I had commented out my `"DATA"` segment so I could have one continuous offset output in my listing.  This will gently remind folks that's not a good idea.